### PR TITLE
Fixed most requirizing errors. Workers still don't work

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <meta content="utf-8" http-equiv="encoding">
   <title>`ili</title>
+  <link rel="stylesheet" type="text/css" href="main.css">
+  <link rel="stylesheet" type="text/css" href="layout.css">
   <script type="text/javascript" src="./js/lib/require.min.js"></script>
   <link href="img/favicon_256.png" type="image/png" rel="icon">
   <meta name="google-site-verification" content="cxpSm-lsEATF7z2pMt1-RCZPSaKRzb6h0RiIjaVQvsE" />
@@ -11,9 +13,8 @@
         // the left side is the module name, and the right side is the path
         // do NOT include the .js extension
         'paths': {
-
           'filesaver': './js/lib/FileSaver.min',
-          'dat': './js/lib/dat.gui.min',
+          'datgui': './js/lib/dat.gui.min',
           'jquery': './js/lib/jquery-2.1.4.min',
           'papaparse': './js/lib/papaparse.min',
 
@@ -49,8 +50,8 @@
           'wk_raycaster': './js/workers/Raycaster'
         },
         /*
-           Libraries that are not AMD compatible need shim to declare their
-           dependencies.
+         Libraries that are not AMD compatible need shim to declare their
+         dependencies.
          */
         'shim': {
           'orbitcontrols': {
@@ -58,6 +59,9 @@
           },
           'stlloader': {
             'deps': ['three']
+          },
+          'datgui': {
+            exports: 'dat'
           }
         }
       });
@@ -72,8 +76,7 @@
       var g_keyPressEvent = g_isWebkit ? 'keydown' : 'keypress';
 
       requirejs(["main"], function(init){
-        // initialize the whole application
-        window.onload = init;
+        init();
       });
 
   </script>
@@ -114,10 +117,10 @@
 <div id="status" hidden></div>
 <div id="map-selector" hidden><input type="text" autocomplete="off"><div class="items"></div></div>
 <div id="drop-target-informer"><div class="message">Drop files here</div></div>
-<dialog id="errors" hidden>
+<div id="errors" hidden>
 Errors:
 <ul></ul>
 <button id="close">Close</button>
-</dialog>
+</div>
 </body>
 </html>

--- a/js/ColorMaps.js
+++ b/js/ColorMaps.js
@@ -1,9 +1,9 @@
 'use strict';
 
 define([
-    "three"
+    'three'
 ],
-function (THREE) {
+function(THREE) {
     /**
      * Base class for color maps.
      *

--- a/js/EventSource.js
+++ b/js/EventSource.js
@@ -1,7 +1,7 @@
 'use strict';
 
 define([],
-function (){
+function() {
     /**
      * Base class that provides event popagation functionality.
      * @param events Events enum type.
@@ -27,4 +27,4 @@ function (){
     };
 
     return EventSource;
-  });
+});

--- a/js/Examples.js
+++ b/js/Examples.js
@@ -19,7 +19,7 @@ function(dat, Workspace) {
         var folder = examplesContainer.addFolder('Examples');
         folder.open();
 
-        var openExample = function () {
+        var openExample = function() {
             g_workspace.download(this.files);
 
             if (this['adjustView'] !== undefined) {
@@ -35,7 +35,7 @@ function(dat, Workspace) {
             {
                 name: 'Stingless bee',
                 files: ['bee/model.stl', 'bee/intensities.csv'],
-                adjustView: function () {
+                adjustView: function() {
                     g_workspace.scene3d.adjustment.alpha = -90;
                     g_workspace.scene3d.adjustment.beta = 10;
                     g_workspace.scene3d.adjustment.gamma = 0;
@@ -50,14 +50,14 @@ function(dat, Workspace) {
             {
                 name: 'Diseased coral',
                 files: ['coral/bg.png', 'coral/intensities.csv'],
-                adjustView: function () {
+                adjustView: function() {
                     g_workspace.colorMapId = 'VIRIDIS';
                 }
             },
             {
                 name: 'Cyanobacteria natural products',
                 files: ['cyano/bg.png', 'cyano/intensities.csv'],
-                adjustView: function () {
+                adjustView: function() {
                     g_workspace.scaleId = Workspace.Scale.LOG.id;
                     g_workspace.colorMapId = 'JET';
                 }
@@ -65,7 +65,7 @@ function(dat, Workspace) {
             {
                 name: 'Human skin metabolome',
                 files: ['human/man.stl', 'human/man_LCMS_small.csv'],
-                adjustView: function () {
+                adjustView: function() {
                     g_workspace.colorMapId = 'VIRIDIS';
 
                     g_workspace.scene3d.adjustment.alpha = -90;
@@ -78,7 +78,7 @@ function(dat, Workspace) {
             }
         ];
 
-        items.forEach(function (item) {
+        items.forEach(function(item) {
             item[item.name] = openExample.bind(item);
             folder.add(item, item.name);
         });

--- a/js/Examples.js
+++ b/js/Examples.js
@@ -1,84 +1,91 @@
 'use strict';
 
-function updateGuiRecursively(gui) {
-    for (var i in gui.__controllers) {
-        gui.__controllers[i].updateDisplay();
-    }
-    for (var i in gui.__folders) {
-        updateGuiRecursively(gui.__folders[i]);
-    }
-}
-
-function Examples() {
-    var examplesContainer = new dat.GUI({autoPlace: false});
-
-    var folder = examplesContainer.addFolder('Examples');
-    folder.open();
-
-    var openExample = function() {
-        g_workspace.download(this.files);
-
-        if (this['adjustView'] !== undefined) {
-            this.adjustView();
-            updateGuiRecursively(g_gui);
+define([
+    'datgui', 'workspace'
+],
+function(dat, Workspace) {
+    function updateGuiRecursively(gui) {
+        for (var i in gui.__controllers) {
+            gui.__controllers[i].updateDisplay();
         }
+        for (var i in gui.__folders) {
+            updateGuiRecursively(gui.__folders[i]);
+        }
+    }
+
+    function Examples() {
+        var examplesContainer = new dat.GUI({autoPlace: false});
+
+        var folder = examplesContainer.addFolder('Examples');
+        folder.open();
+
+        var openExample = function () {
+            g_workspace.download(this.files);
+
+            if (this['adjustView'] !== undefined) {
+                this.adjustView();
+                updateGuiRecursively(g_gui);
+            }
+        };
+        var items = [
+            {
+                name: '3D-MASSOMICS meeting mockup',
+                files: ['3dmassomics/bg.png', '3dmassomics/intensities.csv'],
+            },
+            {
+                name: 'Stingless bee',
+                files: ['bee/model.stl', 'bee/intensities.csv'],
+                adjustView: function () {
+                    g_workspace.scene3d.adjustment.alpha = -90;
+                    g_workspace.scene3d.adjustment.beta = 10;
+                    g_workspace.scene3d.adjustment.gamma = 0;
+                    g_workspace.scene3d.adjustment.x = 0;
+                    g_workspace.scene3d.adjustment.y = 0;
+                    g_workspace.scene3d.adjustment.z = 0;
+
+                    g_workspace.scaleId = Workspace.Scale.LOG.id;
+                    g_workspace.colorMapId = 'VIRIDIS';
+                }
+            },
+            {
+                name: 'Diseased coral',
+                files: ['coral/bg.png', 'coral/intensities.csv'],
+                adjustView: function () {
+                    g_workspace.colorMapId = 'VIRIDIS';
+                }
+            },
+            {
+                name: 'Cyanobacteria natural products',
+                files: ['cyano/bg.png', 'cyano/intensities.csv'],
+                adjustView: function () {
+                    g_workspace.scaleId = Workspace.Scale.LOG.id;
+                    g_workspace.colorMapId = 'JET';
+                }
+            },
+            {
+                name: 'Human skin metabolome',
+                files: ['human/man.stl', 'human/man_LCMS_small.csv'],
+                adjustView: function () {
+                    g_workspace.colorMapId = 'VIRIDIS';
+
+                    g_workspace.scene3d.adjustment.alpha = -90;
+                    g_workspace.scene3d.adjustment.beta = 0;
+                    g_workspace.scene3d.adjustment.gamma = -45;
+                    g_workspace.scene3d.adjustment.x = 0;
+                    g_workspace.scene3d.adjustment.y = -13;
+                    g_workspace.scene3d.adjustment.z = 0;
+                }
+            }
+        ];
+
+        items.forEach(function (item) {
+            item[item.name] = openExample.bind(item);
+            folder.add(item, item.name);
+        });
+
+        var container = document.getElementById('examples-container');
+        container.appendChild(examplesContainer.domElement);
     };
-    var items = [
-        {
-            name: '3D-MASSOMICS meeting mockup',
-            files: ['3dmassomics/bg.png', '3dmassomics/intensities.csv'],
-        },
-        {
-            name: 'Stingless bee',
-            files: ['bee/model.stl', 'bee/intensities.csv'],
-            adjustView: function() {
-                g_workspace.scene3d.adjustment.alpha = -90;
-                g_workspace.scene3d.adjustment.beta = 10;
-                g_workspace.scene3d.adjustment.gamma = 0;
-                g_workspace.scene3d.adjustment.x = 0;
-                g_workspace.scene3d.adjustment.y = 0;
-                g_workspace.scene3d.adjustment.z = 0;
 
-                g_workspace.scaleId = Workspace.Scale.LOG.id;
-                g_workspace.colorMapId = 'VIRIDIS';
-            }
-        },
-        {
-            name: 'Diseased coral',
-            files: ['coral/bg.png', 'coral/intensities.csv'],
-            adjustView: function() {
-                g_workspace.colorMapId = 'VIRIDIS';
-            }
-        },
-        {
-            name: 'Cyanobacteria natural products',
-            files: ['cyano/bg.png', 'cyano/intensities.csv'],
-            adjustView: function() {
-                g_workspace.scaleId = Workspace.Scale.LOG.id;
-                g_workspace.colorMapId = 'JET';
-            }
-        },
-        {
-            name: 'Human skin metabolome',
-            files: ['human/man.stl', 'human/man_LCMS_small.csv'],
-            adjustView: function() {
-                g_workspace.colorMapId = 'VIRIDIS';
-
-                g_workspace.scene3d.adjustment.alpha = -90;
-                g_workspace.scene3d.adjustment.beta = 0;
-                g_workspace.scene3d.adjustment.gamma = -45;
-                g_workspace.scene3d.adjustment.x = 0;
-                g_workspace.scene3d.adjustment.y = -13;
-                g_workspace.scene3d.adjustment.z = 0;
-            }
-        }
-    ];
-
-    items.forEach(function(item) {
-        item[item.name] = openExample.bind(item);
-        folder.add(item, item.name);
-    });
-
-    var container = document.getElementById('examples-container');
-    container.appendChild(examplesContainer.domElement);
-};
+    return Examples;
+});

--- a/js/MapSelector.js
+++ b/js/MapSelector.js
@@ -1,15 +1,17 @@
-define([],
-function () {
+/**
+ * UI control (#map-selector) which let the user to select an active map
+ * (measurement). Text input lets type filter for map name. Item list (.items)
+ * shows only items that contain the filter's substring (and highlights it).
+ *
+ * @param {Workspace} workspace.
+ * @param {HTMLDivElement} div Main HTML element (#map-selector).
+ * @mapName {HTMLElement|SGVElement} mapName Element to show current map name.
+ */
 
-    /**
-     * UI control (#map-selector) which let the user to select an active map
-     * (measurement). Text input lets type filter for map name. Item list (.items)
-     * shows only items that contain the filter's substring (and highlights it).
-     *
-     * @param {Workspace} workspace.
-     * @param {HTMLDivElement} div Main HTML element (#map-selector).
-     * @mapName {HTMLElement|SGVElement} mapName Element to show current map name.
-     */
+'use strict';
+
+define([],
+function() {
     function MapSelector(workspace, div, mapName) {
         this._workspace = workspace;
         this._div = div;

--- a/js/Scene2D.js
+++ b/js/Scene2D.js
@@ -1,211 +1,220 @@
-function Scene2D() {
-    EventSource.call(this, Scene2D.Events);
+'use strict';
 
-    this._spotBorder = 0.05;
-    this._imageURL = null;
-    this._width = 0;
-    this._height = 0;
-    this._spots = null;
-};
+define([
+    'eventsource'
+],
+function(EventSource) {
+    function Scene2D() {
+        EventSource.call(this, Scene2D.Events);
 
-Scene2D.Events = {
-    IMAGE_CHANGE: 'image_change',
-    PARAM_CHANGE: 'param_change',
-    SPOTS_CHANGE: 'spots-change',
-};
+        this._spotBorder = 0.05;
+        this._imageURL = null;
+        this._width = 0;
+        this._height = 0;
+        this._spots = null;
+    };
 
-Scene2D.prototype = Object.create(EventSource.prototype, {
-    width: {
-        get: function() {
-            return this._width;
-        }
-    },
+    Scene2D.Events = {
+        IMAGE_CHANGE: 'image_change',
+        PARAM_CHANGE: 'param_change',
+        SPOTS_CHANGE: 'spots-change',
+    };
 
-    height: {
-        get: function() {
-            return this._height;
-        }
-    },
-
-    hasImage: {
-        get: function() {
-            return !!this._imageURL;
-        }
-    },
-
-    setImage: {
-        value: function(imageURL, width, height) {
-            if (this._imageURL) {
-                URL.revokeObjectURL(this._imageURL);
+    Scene2D.prototype = Object.create(EventSource.prototype, {
+        width: {
+            get: function () {
+                return this._width;
             }
-            this._imageURL = imageURL;
-            this._width = width;
-            this._height = height;
-            this._notify(Scene2D.Events.IMAGE_CHANGE);
-        }
-    },
-
-    imageURL: {
-        get: function() {
-            return this._imageURL;
-        }
-    },
-
-    resetImage: {
-        value: function() {
-            this.setImage(null, 0, 0);
-        }
-    },
-
-    spotBorder: {
-        get: function() {
-            return this._spotBorder;
         },
 
-        set: function(value) {
-            if (this._spotBorder == value) return;
-            if (value < 0.0) value = 0.0;
-            if (value > 1.0) value = 1.0;
-            this._spotBorder = value;
-            this._notify(Scene2D.Events.PARAM_CHANGE);
-        }
-    },
-
-    spots: {
-        get: function() {
-            return this._spots;
+        height: {
+            get: function () {
+                return this._height;
+            }
         },
 
-        set: function(value) {
-            if (value) {
-                this._spots = value.map(function(s) {
-                    return {
-                        x: s.x,
-                        y: s.y,
-                        r: s.r,
-                        name: s.name,
-                        intensity: s.intensity,
-                    };
-                });
-            } else {
-                this._spots = null;
-                return;
+        hasImage: {
+            get: function () {
+                return !!this._imageURL;
             }
+        },
 
-            this._notify(Scene2D.Events.SPOTS_CHANGE);
-        }
-    },
-
-    updateIntensities: {
-        value: function(spots) {
-            if (!this._spots) return;
-            var startTime = new Date();
-
-            for (var i = 0; i < this._spots.length; i++) {
-                this._spots[i].intensity = spots[i] && spots[i].intensity;
+        setImage: {
+            value: function (imageURL, width, height) {
+                if (this._imageURL) {
+                    URL.revokeObjectURL(this._imageURL);
+                }
+                this._imageURL = imageURL;
+                this._width = width;
+                this._height = height;
+                this._notify(Scene2D.Events.IMAGE_CHANGE);
             }
-            this._notify(Scene2D.Events.SPOTS_CHANGE);
-            var endTime = new Date();
-            console.log('Spots updating time: ' +
+        },
+
+        imageURL: {
+            get: function () {
+                return this._imageURL;
+            }
+        },
+
+        resetImage: {
+            value: function () {
+                this.setImage(null, 0, 0);
+            }
+        },
+
+        spotBorder: {
+            get: function () {
+                return this._spotBorder;
+            },
+
+            set: function (value) {
+                if (this._spotBorder == value) return;
+                if (value < 0.0) value = 0.0;
+                if (value > 1.0) value = 1.0;
+                this._spotBorder = value;
+                this._notify(Scene2D.Events.PARAM_CHANGE);
+            }
+        },
+
+        spots: {
+            get: function () {
+                return this._spots;
+            },
+
+            set: function (value) {
+                if (value) {
+                    this._spots = value.map(function (s) {
+                        return {
+                            x: s.x,
+                            y: s.y,
+                            r: s.r,
+                            name: s.name,
+                            intensity: s.intensity,
+                        };
+                    });
+                } else {
+                    this._spots = null;
+                    return;
+                }
+
+                this._notify(Scene2D.Events.SPOTS_CHANGE);
+            }
+        },
+
+        updateIntensities: {
+            value: function (spots) {
+                if (!this._spots) return;
+                var startTime = new Date();
+
+                for (var i = 0; i < this._spots.length; i++) {
+                    this._spots[i].intensity = spots[i] && spots[i].intensity;
+                }
+                this._notify(Scene2D.Events.SPOTS_CHANGE);
+                var endTime = new Date();
+                console.log('Spots updating time: ' +
                     (endTime.valueOf() - startTime.valueOf()) / 1000);
-        }
-    },
-
-    colorMap: {
-        get: function() {
-            return this._colorMap;
+            }
         },
 
-        set: function(value) {
-            this._colorMap = value;
-            this._notify(Scene2D.Events.SPOTS_CHANGE);
-        }
-    },
+        colorMap: {
+            get: function () {
+                return this._colorMap;
+            },
 
-    exportImage: {
-        value: function(canvas) {
-            return new Promise(function(accept, reject) {
-                if (!this._imageURL) {
-                    reject();
-                    return;
-                }
-                var image = new Image();
-                image.width = this.width;
-                image.height = this.height;
-                image.onload = function() {
+            set: function (value) {
+                this._colorMap = value;
+                this._notify(Scene2D.Events.SPOTS_CHANGE);
+            }
+        },
+
+        exportImage: {
+            value: function (canvas) {
+                return new Promise(function (accept, reject) {
+                    if (!this._imageURL) {
+                        reject();
+                        return;
+                    }
+                    var image = new Image();
+                    image.width = this.width;
+                    image.height = this.height;
+                    image.onload = function () {
+                        var ctx = canvas.getContext('2d');
+                        ctx.drawImage(image, 0, 0);
+                        accept();
+                    };
+                    image.onerror = function (event) {
+                        console.log('Failed to load SVG', event);
+                        reject();
+                    }
+                    image.src = this._imageURL;
+                }.bind(this));
+            }
+        },
+
+        exportSpots: {
+            value: function (canvas) {
+                var spots = this._spots;
+                var color = new THREE.Color();
+                var colorMap = this._colorMap;
+                var borderGradientSuffix = this._spotBorder + ')';
+                return new Promise(function (accept, reject) {
+                    if (!spots) {
+                        reject();
+                        return;
+                    }
+
                     var ctx = canvas.getContext('2d');
-                    ctx.drawImage(image, 0, 0);
-                    accept();
-                };
-                image.onerror = function(event) {
-                    console.log('Failed to load SVG', event);
-                    reject();
-                }
-                image.src = this._imageURL;
-            }.bind(this));
-        }
-    },
+                    for (var i = 0; i < spots.length; i++) {
+                        var s = spots[i];
+                        if (isNaN(s.intensity)) continue;
+                        colorMap.map(color, s.intensity);
 
-    exportSpots: {
-        value: function(canvas) {
-            var spots = this._spots;
-            var color = new THREE.Color();
-            var colorMap = this._colorMap;
-            var borderGradientSuffix = this._spotBorder + ')';
-            return new Promise(function(accept, reject) {
-                if (!spots) {
-                    reject();
-                    return;
-                }
-
-                var ctx = canvas.getContext('2d');
-                for (var i = 0; i < spots.length; i++) {
-                    var s = spots[i];
-                    if (isNaN(s.intensity)) continue;
-                    colorMap.map(color, s.intensity);
-
-                    ctx.beginPath();
-                    ctx.arc(s.x, s.y, s.r, 0, 2 * Math.PI, false);
-                    var gdx = ctx.createRadialGradient(s.x, s.y, 0, s.x, s.y, s.r);
-                    var rgba = 'rgba(' + Math.round(color.r * 255) + ',' + // was: var rgba = 'rgba(' + Math.round(color.r * 155) + ',' +
+                        ctx.beginPath();
+                        ctx.arc(s.x, s.y, s.r, 0, 2 * Math.PI, false);
+                        var gdx = ctx.createRadialGradient(s.x, s.y, 0, s.x, s.y, s.r);
+                        var rgba = 'rgba(' + Math.round(color.r * 255) + ',' + // was: var rgba = 'rgba(' + Math.round(color.r * 155) + ',' +
                             Math.round(color.g * 255) + ',' + Math.round(color.b * 255) + ',';
 
-                    gdx.addColorStop(0, rgba + '1)');
-                    gdx.addColorStop(1, rgba + borderGradientSuffix);
-                    ctx.fillStyle = gdx;
-                    ctx.fill();
-                }
+                        gdx.addColorStop(0, rgba + '1)');
+                        gdx.addColorStop(1, rgba + borderGradientSuffix);
+                        ctx.fillStyle = gdx;
+                        ctx.fill();
+                    }
 
-                accept();
-            }.bind(this));
-        }
-    },
+                    accept();
+                }.bind(this));
+            }
+        },
 
-    findSpot: {
-        value: function(point) {
-            var spots = this._spots;
-            return new Promise(function(accept, reject) {
-                if (!spots) {
-                    reject();
-                    return;
-                }
+        findSpot: {
+            value: function (point) {
+                var spots = this._spots;
+                return new Promise(function (accept, reject) {
+                    if (!spots) {
+                        reject();
+                        return;
+                    }
 
-                for (var i = 0; i < spots.length; i++) {
-                    var s = spots[i];
-                    if (!isNaN(s.intensity) &&
+                    for (var i = 0; i < spots.length; i++) {
+                        var s = spots[i];
+                        if (!isNaN(s.intensity) &&
                             point.x > s.x - s.r && point.x < s.x + s.r &&
                             point.y > s.y - s.r && point.y < s.y + s.r) {
-                        var dx = point.x - s.x;
-                        var dy = point.y - s.y;
-                        if (dx * dx + dy * dy < s.r * s.r) {
-                            accept(s)
-                            return;
+                            var dx = point.x - s.x;
+                            var dy = point.y - s.y;
+                            if (dx * dx + dy * dy < s.r * s.r) {
+                                accept(s)
+                                return;
+                            }
                         }
                     }
-                }
 
-                accept(null);
-            });
-        }
-    },
+                    accept(null);
+                });
+            }
+        },
+    });
+
+    return Scene2D;
 });

--- a/js/Scene2D.js
+++ b/js/Scene2D.js
@@ -22,25 +22,25 @@ function(EventSource) {
 
     Scene2D.prototype = Object.create(EventSource.prototype, {
         width: {
-            get: function () {
+            get: function() {
                 return this._width;
             }
         },
 
         height: {
-            get: function () {
+            get: function() {
                 return this._height;
             }
         },
 
         hasImage: {
-            get: function () {
+            get: function() {
                 return !!this._imageURL;
             }
         },
 
         setImage: {
-            value: function (imageURL, width, height) {
+            value: function(imageURL, width, height) {
                 if (this._imageURL) {
                     URL.revokeObjectURL(this._imageURL);
                 }
@@ -52,23 +52,23 @@ function(EventSource) {
         },
 
         imageURL: {
-            get: function () {
+            get: function() {
                 return this._imageURL;
             }
         },
 
         resetImage: {
-            value: function () {
+            value: function() {
                 this.setImage(null, 0, 0);
             }
         },
 
         spotBorder: {
-            get: function () {
+            get: function() {
                 return this._spotBorder;
             },
 
-            set: function (value) {
+            set: function(value) {
                 if (this._spotBorder == value) return;
                 if (value < 0.0) value = 0.0;
                 if (value > 1.0) value = 1.0;
@@ -78,13 +78,13 @@ function(EventSource) {
         },
 
         spots: {
-            get: function () {
+            get: function() {
                 return this._spots;
             },
 
-            set: function (value) {
-                if (value) {
-                    this._spots = value.map(function (s) {
+            set: function(value) {
+                if (value){
+                    this._spots = value.map(function(s) {
                         return {
                             x: s.x,
                             y: s.y,
@@ -103,7 +103,7 @@ function(EventSource) {
         },
 
         updateIntensities: {
-            value: function (spots) {
+            value: function(spots) {
                 if (!this._spots) return;
                 var startTime = new Date();
 
@@ -118,19 +118,19 @@ function(EventSource) {
         },
 
         colorMap: {
-            get: function () {
+            get: function() {
                 return this._colorMap;
             },
 
-            set: function (value) {
+            set: function(value) {
                 this._colorMap = value;
                 this._notify(Scene2D.Events.SPOTS_CHANGE);
             }
         },
 
         exportImage: {
-            value: function (canvas) {
-                return new Promise(function (accept, reject) {
+            value: function(canvas) {
+                return new Promise(function(accept, reject) {
                     if (!this._imageURL) {
                         reject();
                         return;
@@ -138,12 +138,12 @@ function(EventSource) {
                     var image = new Image();
                     image.width = this.width;
                     image.height = this.height;
-                    image.onload = function () {
+                    image.onload = function() {
                         var ctx = canvas.getContext('2d');
                         ctx.drawImage(image, 0, 0);
                         accept();
                     };
-                    image.onerror = function (event) {
+                    image.onerror = function(event) {
                         console.log('Failed to load SVG', event);
                         reject();
                     }
@@ -153,12 +153,12 @@ function(EventSource) {
         },
 
         exportSpots: {
-            value: function (canvas) {
+            value: function(canvas) {
                 var spots = this._spots;
                 var color = new THREE.Color();
                 var colorMap = this._colorMap;
                 var borderGradientSuffix = this._spotBorder + ')';
-                return new Promise(function (accept, reject) {
+                return new Promise(function(accept, reject) {
                     if (!spots) {
                         reject();
                         return;
@@ -188,9 +188,9 @@ function(EventSource) {
         },
 
         findSpot: {
-            value: function (point) {
+            value: function(point) {
                 var spots = this._spots;
-                return new Promise(function (accept, reject) {
+                return new Promise(function(accept, reject) {
                     if (!spots) {
                         reject();
                         return;
@@ -213,7 +213,7 @@ function(EventSource) {
                     accept(null);
                 });
             }
-        },
+        }
     });
 
     return Scene2D;

--- a/js/Scene3D.js
+++ b/js/Scene3D.js
@@ -37,25 +37,25 @@ function(EventSource, THREE) {
         CHANGE: 'change',
     };
 
-    Scene3D._makeLightProperty = function (field) {
-        return Scene3D._makeProxyProperty(field, ['intensity'], function () {
+    Scene3D._makeLightProperty = function(field) {
+        return Scene3D._makeProxyProperty(field, ['intensity'], function() {
             this._notify(Scene3D.Events.CHANGE);
         });
     };
 
-    Scene3D._makeProxyProperty = function (field, properties, callback) {
+    Scene3D._makeProxyProperty = function(field, properties, callback) {
         var proxy;
         return {
-            get: function () {
+            get: function() {
                 if (proxy) return proxy;
                 proxy = {};
                 for (var i = 0; i < properties.length; i++) {
                     Object.defineProperty(proxy, properties[i], {
-                        get: function (prop) {
+                        get: function(prop) {
                             return this[field][prop]
                         }.bind(this, properties[i]),
 
-                        set: function (prop, value) {
+                        set: function(prop, value) {
                             this[field][prop] = value;
                             callback.call(this);
                         }.bind(this, properties[i])
@@ -64,7 +64,7 @@ function(EventSource, THREE) {
                 return proxy;
             },
 
-            set: function (value) {
+            set: function(value) {
                 for (var i = 0; i < properties.length; i++) {
                     var prop = properties[i]
                     this[field][prop] = value[prop];
@@ -76,7 +76,7 @@ function(EventSource, THREE) {
 
     Scene3D.prototype = Object.create(EventSource.prototype, {
         clone: {
-            value: function (eventName, listener) {
+            value: function(eventName, listener) {
                 var result = new Scene3D();
                 result.frontLight = this.frontLight;
                 result.color = this.color;
@@ -99,11 +99,11 @@ function(EventSource, THREE) {
         frontLight: Scene3D._makeLightProperty('_frontLight'),
 
         color: {
-            get: function () {
+            get: function() {
                 return '#' + this._color.getHexString();
             },
 
-            set: function (value) {
+            set: function(value) {
                 var color = new THREE.Color(value);
                 if (color.equals(this._color)) return;
                 this._color.set(color);
@@ -115,11 +115,11 @@ function(EventSource, THREE) {
         },
 
         backgroundColor: {
-            get: function () {
+            get: function() {
                 return '#' + this._backgroundColor.getHexString();
             },
 
-            set: function (value) {
+            set: function(value) {
                 var color = new THREE.Color(value);
                 if (color.equals(this._backgroundColor)) return;
                 this._backgroundColor.set(color);
@@ -128,17 +128,17 @@ function(EventSource, THREE) {
         },
 
         backgroundColorValue: {
-            get: function () {
+            get: function() {
                 return this._backgroundColor;
             }
         },
 
         spotBorder: {
-            get: function () {
+            get: function() {
                 return this._spotBorder;
             },
 
-            set: function (value) {
+            set: function(value) {
                 if (this._spotBorder == value) return;
                 if (value < 0.0) value = 0.0;
                 if (value > 1.0) value = 1.0;
@@ -151,7 +151,7 @@ function(EventSource, THREE) {
         },
 
         adjustment: Scene3D._makeProxyProperty('_adjustment', ['x', 'y', 'z', 'alpha', 'beta', 'gamma'],
-            function () {
+            function() {
                 if (this._mesh) {
                     this._applyAdjustment();
                     this._notify(Scene3D.Events.CHANGE);
@@ -159,11 +159,11 @@ function(EventSource, THREE) {
             }),
 
         spots: {
-            get: function () {
+            get: function() {
                 return this._spots;
             },
 
-            set: function (value) {
+            set: function(value) {
                 if (value) {
                     this._spots = new Array(value.length);
                     for (var i = 0; i < value.length; i++) {
@@ -192,7 +192,7 @@ function(EventSource, THREE) {
         },
 
         updateIntensities: {
-            value: function (spots) {
+            value: function(spots) {
                 if (!this._spots) return;
 
                 for (var i = 0; i < this._spots.length; i++) {
@@ -206,11 +206,11 @@ function(EventSource, THREE) {
         },
 
         mapping: {
-            get: function () {
+            get: function() {
                 return this._mapping;
             },
 
-            set: function (value) {
+            set: function(value) {
                 if (!this._spots) throw "Mapping donesn't make sense without spots";
                 this._mapping = value;
                 if (this._mesh) {
@@ -221,11 +221,11 @@ function(EventSource, THREE) {
         },
 
         geometry: {
-            get: function () {
+            get: function() {
                 return this._mesh ? this._mesh.geometry : null;
             },
 
-            set: function (geometry) {
+            set: function(geometry) {
                 if (!this._mesh && !geometry) return;
                 if (this._mesh) this._meshContainer.remove(this._mesh);
                 this._mapping = null;
@@ -244,11 +244,11 @@ function(EventSource, THREE) {
         },
 
         colorMap: {
-            get: function () {
+            get: function() {
                 return this._colorMap;
             },
 
-            set: function (value) {
+            set: function(value) {
                 this._colorMap = value;
                 if (this._mesh && this._spots && this._mapping) {
                     this._recolor();
@@ -258,20 +258,20 @@ function(EventSource, THREE) {
         },
 
         position: {
-            get: function () {
+            get: function() {
                 return this._scene.position.clone();
             }
         },
 
         render: {
-            value: function (renderer, camera) {
+            value: function(renderer, camera) {
                 this._frontLight.position.set(camera.position.x, camera.position.y, camera.position.z);
                 renderer.render(this._scene, camera);
             }
         },
 
         raycast: {
-            value: function (raycaster) {
+            value: function(raycaster) {
                 if (!this._mesh || !this._spots || !this._mapping) return null;
                 var message = {
                     positions: this._mesh.geometry.attributes.position.array,
@@ -283,8 +283,8 @@ function(EventSource, THREE) {
                 var spots = this._spots;
                 var worker = new Worker('js/workers/Raycaster.js');
 
-                var promise = new Promise(function (accept, reject) {
-                    worker.onmessage = function (event) {
+                var promise = new Promise(function(accept, reject) {
+                    worker.onmessage = function(event) {
                         worker.terminate();
                         var face = event.data;
                         var spotIndex = -1;
@@ -296,7 +296,7 @@ function(EventSource, THREE) {
                         }
                         accept(spots[spotIndex]);
                     };
-                    worker.onerror = function (event) {
+                    worker.onerror = function(event) {
                         console.log('Reycasting failed', event);
                         worker.terminate();
                         reject();
@@ -305,7 +305,7 @@ function(EventSource, THREE) {
                 });
 
                 Object.defineProperty(promise, 'cancel', {
-                    value: function () {
+                    value: function() {
                         worker.terminate();
                     }
                 });
@@ -315,7 +315,7 @@ function(EventSource, THREE) {
         },
 
         spotToWorld: {
-            value: function (spot) {
+            value: function(spot) {
                 if (!this._mesh) return null;
 
                 var position = new THREE.Vector3(spot.x, spot.y, spot.z);
@@ -325,7 +325,7 @@ function(EventSource, THREE) {
         },
 
         _recolor: {
-            value: function () {
+            value: function() {
                 var startTime = new Date();
                 var geometry = this.geometry;
                 var mapping = this.mapping;
@@ -394,14 +394,14 @@ function(EventSource, THREE) {
         },
 
         _applyAdjustment: {
-            value: function () {
+            value: function() {
                 this._meshContainer.rotation.x = this._adjustment.alpha * Math.PI / 180;
                 this._meshContainer.rotation.y = this._adjustment.beta * Math.PI / 180;
                 this._meshContainer.rotation.z = this._adjustment.gamma * Math.PI / 180;
                 this._meshContainer.position.copy(this._adjustment);
                 this._meshContainer.updateMatrix();
             }
-        },
+        }
     });
 
     return Scene3D;

--- a/js/Scene3D.js
+++ b/js/Scene3D.js
@@ -1,8 +1,8 @@
 'use strict';
 
 define([
-        'eventsource', 'three'
-    ],
+    'eventsource', 'three'
+],
 function(EventSource, THREE) {
     function Scene3D() {
         EventSource.call(this, Scene3D.Events);

--- a/js/SpotLabel2D.js
+++ b/js/SpotLabel2D.js
@@ -1,10 +1,9 @@
 'use strict';
 
 define([
-    'spotlabelbase',
-    'common'
+    'spotlabelbase', 'common'
 ],
-function (SpotLabelBase, asProps){
+function(SpotLabelBase, asProps) {
     function SpotLabel2D(view) {
         SpotLabelBase.apply(this);
         this._view = view;
@@ -39,4 +38,4 @@ function (SpotLabelBase, asProps){
     }));
 
     return SpotLabel2D;
-  });
+});

--- a/js/SpotLabelBase.js
+++ b/js/SpotLabelBase.js
@@ -3,7 +3,7 @@
 define([
     'common'
 ],
-function (asProps){
+function(asProps) {
     function SpotLabelBase() {
         this._div = null;
     }

--- a/js/View2D.js
+++ b/js/View2D.js
@@ -1,11 +1,9 @@
 'use strict';
 
 define([
-    'three',
-    'scene2d',
-    'spotlabel2d'
+    'three', 'scene2d', 'spotlabel2d'
 ],
-function (THREE, Scene2D, SpotLabel2D){
+function(THREE, Scene2D, SpotLabel2D) {
     function View2D(workspace, div) {
         this._div = div;
         this._img = this._div.querySelector('img');

--- a/js/View3D.js
+++ b/js/View3D.js
@@ -39,7 +39,7 @@ function(OrbitControls, THREE) {
 
     View3D.prototype = Object.create(null, {
         prepareUpdateLayout: {
-            value: function () {
+            value: function() {
                 this._left = this._div.offsetLeft;
                 this._top = this._div.offsetTop;
                 this._width = this._div.offsetWidth;
@@ -50,50 +50,50 @@ function(OrbitControls, THREE) {
         },
 
         div: {
-            get: function () {
+            get: function() {
                 return this._div;
             }
         },
 
         finishUpdateLayout: {
-            value: function () {
+            value: function() {
                 this._camera.aspect = this.width / this.height;
                 this._camera.updateProjectionMatrix();
             }
         },
 
         camera: {
-            get: function () {
+            get: function() {
                 return this._camera;
             }
         },
 
         left: {
-            get: function () {
+            get: function() {
                 return this._left;
             }
         },
 
         top: {
-            get: function () {
+            get: function() {
                 return this._top;
             }
         },
 
         width: {
-            get: function () {
+            get: function() {
                 return this._width;
             }
         },
 
         height: {
-            get: function () {
+            get: function() {
                 return this._height;
             }
         },
 
         setupRaycaster: {
-            value: function (raycaster, pageX, pageY) {
+            value: function(raycaster, pageX, pageY) {
                 var x = pageX - this._left;
                 var y = pageY - this._top;
                 var coords = new THREE.Vector2(x * 2 / this._width - 1, 1 - y * 2 / this._height);
@@ -102,7 +102,7 @@ function(OrbitControls, THREE) {
         },
 
         projectPosition: {
-            value: function (position) {
+            value: function(position) {
                 var p = new THREE.Vector3().copy(position)
                 p.project(this._camera);
 
@@ -114,7 +114,7 @@ function(OrbitControls, THREE) {
         },
 
         onAnimationFrame: {
-            value: function (now) {
+            value: function(now) {
                 if (this._autorotation == 0.0) {
                     return;
                 } else {
@@ -131,11 +131,11 @@ function(OrbitControls, THREE) {
         },
 
         autorotation: {
-            get: function () {
+            get: function() {
                 return this._autorotation;
             },
 
-            set: function (value) {
+            set: function(value) {
                 this._autorotation = value;
                 this._autorotationStart = performance.now;
                 if (this._autorotation != 0.0) {
@@ -145,20 +145,20 @@ function(OrbitControls, THREE) {
         },
 
         _onOrbitStart: {
-            value: function () {
+            value: function() {
                 this.autorotation = 0;
             }
         },
 
         _onDoubleClick: {
-            value: function (event) {
+            value: function(event) {
                 if (this.autorotation) {
                     this.autorotation = 0;
                 } else {
                     this.autorotation = event.ctrlKey ? -1 : 1;
                 }
             }
-        },
+        }
     });
 
     return View3D;

--- a/js/View3D.js
+++ b/js/View3D.js
@@ -1,8 +1,8 @@
 'use strict';
 
 define([
-        'orbitcontrols', 'three'
-    ],
+    'orbitcontrols', 'three'
+],
 function(OrbitControls, THREE) {
     /**
      * View indise ViewGroup3D. All View3Ds share single canvas from the group.
@@ -160,5 +160,6 @@ function(OrbitControls, THREE) {
             }
         },
     });
+
     return View3D;
 });

--- a/js/ViewContainer.js
+++ b/js/ViewContainer.js
@@ -1,12 +1,9 @@
 'use strict';
 
 define([
-    'view2d',
-    'viewgroup3d',
-    'viewlegend',
-    'workspace'
+    'view2d', 'viewgroup3d', 'viewlegend', 'workspace'
 ],
-function (View2D, ViewGroup3D, ViewLegend, Workspace){
+function(View2D, ViewGroup3D, ViewLegend, Workspace) {
     function ViewContainer(workspace, div) {
         this._workspace = workspace;
         this._div = div;

--- a/js/ViewGroup3D.js
+++ b/js/ViewGroup3D.js
@@ -1,12 +1,9 @@
 'use strict';
 
 define([
-    'three',
-    'scene3d',
-    'view3d',
-    'spotlabel3d'
+    'three', 'scene3d', 'view3d', 'spotlabel3d'
 ],
-function (THREE, Scene3D, View3D, SpotLabel3D){
+function(THREE, Scene3D, View3D, SpotLabel3D) {
     /**
      * Group of View3D's. Manages shared objects: workspace, renderer, canvas.
      *

--- a/js/ViewLegend.js
+++ b/js/ViewLegend.js
@@ -1,7 +1,7 @@
 'use strict';
 
 define([],
-function () {
+function() {
     function ViewLegend(workspace, svg) {
         this._workspace = workspace;
         this._svg = svg;
@@ -71,4 +71,4 @@ function () {
     });
 
     return ViewLegend;
-})
+});

--- a/js/Workspace.js
+++ b/js/Workspace.js
@@ -1,8 +1,8 @@
 'use strict';
 
 define([
-        'colormaps', 'eventsource', 'scene2d', 'scene3d', 'three'
-    ],
+    'colormaps', 'eventsource', 'scene2d', 'scene3d', 'three'
+],
 function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
     /**
      * Main application workspace. It works in 3 modes:

--- a/js/Workspace.js
+++ b/js/Workspace.js
@@ -65,7 +65,7 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
         LOG: {
             id: 'log',
             function: Math.log10,
-            filter: function (x) {
+            filter: function(x) {
                 return x > 0.0 && x < Infinity;
             },
             legend: 'log',
@@ -73,17 +73,17 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
 
         LINEAR: {
             id: 'linear',
-            function: function (x) {
+            function: function(x) {
                 return x;
             },
-            filter: function (x) {
+            filter: function(x) {
                 return x > -Infinity && x < Infinity;
             },
             legend: '',
         }
     };
 
-    Workspace.getScaleById = function (id) {
+    Workspace.getScaleById = function(id) {
         for (var i in Workspace.Scale) {
             if (Workspace.Scale[i].id == id) return Workspace.Scale[i];
         }
@@ -128,12 +128,12 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
          * Switches the workspace to MODE_2D and starts image loading.
          */
         loadImage: {
-            value: function (blob) {
+            value: function(blob) {
                 this.mode = Workspace.Mode.MODE_2D;
 
                 this._scene2d.resetImage();
                 this._doTask(Workspace.TaskType.LOAD_IMAGE, blob).
-                    then(function (result) {
+                    then(function(result) {
                         this._scene2d.setImage(result.url, result.width, result.height);
                     }.bind(this));
             }
@@ -143,11 +143,11 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
          * Switches the workspace to MODE_3D and starts mesh loading.
          */
         loadMesh: {
-            value: function (blob) {
+            value: function(blob) {
                 this.mode = Workspace.Mode.MODE_3D;
 
                 this.mesh = null;
-                this._doTask(Workspace.TaskType.LOAD_MESH, blob).then(function (result) {
+                this._doTask(Workspace.TaskType.LOAD_MESH, blob).then(function(result) {
                     var geometry = new THREE.BufferGeometry();
                     for (var name in result.attributes) {
                         var attribute = result.attributes[name];
@@ -167,9 +167,9 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
          * Starts loading intensities file.
          */
         loadIntensities: {
-            value: function (blob) {
+            value: function(blob) {
                 this._doTask(Workspace.TaskType.LOAD_MEASURES, blob).
-                    then(function (result) {
+                    then(function(result) {
                         this._spots = result.spots;
                         this._measures = result.measures;
                         this._activeMeasure = null;
@@ -185,16 +185,16 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
         },
 
         download: {
-            value: function (fileNames) {
+            value: function(fileNames) {
                 if (!fileNames) return;
 
-                fileNames = fileNames.filter(function (name) {
+                fileNames = fileNames.filter(function(name) {
                     return name != '';
                 });
                 if (!fileNames.length) return;
 
                 this._doTask(Workspace.TaskType.DOWNLOAD, fileNames).
-                    then(function (result) {
+                    then(function(result) {
                         for (var i = 0; i < result.items.length; i++) {
                             var blob = result.items[i].blob;
 
@@ -227,7 +227,7 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
          * @param {index} Index in the this.measures list.
          */
         selectMap: {
-            value: function (index) {
+            value: function(index) {
                 if (!this._measures) return;
 
                 this._activeMeasure = this._measures[index];
@@ -237,17 +237,17 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
         },
 
         mapName: {
-            get: function () {
+            get: function() {
                 return this._activeMeasure ? this._activeMeasure.name : '';
             }
         },
 
         autoMinMax: {
-            get: function () {
+            get: function() {
                 return this._autoMinMax;
             },
 
-            set: function (value) {
+            set: function(value) {
                 this._autoMinMax = !!value;
                 if (this._autoMinMax) {
                     this._updateMinMaxValues() && this._updateIntensities();
@@ -257,11 +257,11 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
         },
 
         minValue: {
-            get: function () {
+            get: function() {
                 return this._minValue;
             },
 
-            set: function (value) {
+            set: function(value) {
                 if (this._autoMinMax) return;
                 this._minValue = Number(value);
                 this._updateIntensities();
@@ -270,11 +270,11 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
         },
 
         maxValue: {
-            get: function () {
+            get: function() {
                 return this._maxValue;
             },
 
-            set: function (value) {
+            set: function(value) {
                 if (this._autoMinMax) return;
                 this._maxValue = Number(value);
                 this._updateIntensities();
@@ -283,20 +283,20 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
         },
 
         errors: {
-            get: function () {
+            get: function() {
                 return this._errors;
             }
         },
 
         clearErrors: {
-            value: function () {
+            value: function() {
                 this._errors = [];
                 this._notify(Workspace.Events.ERRORS_CHANGE);
             }
         },
 
         _addError: {
-            value: function (message) {
+            value: function(message) {
                 this._errors.push(message);
                 this._notify(Workspace.Events.ERRORS_CHANGE);
             }
@@ -306,13 +306,13 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
          * Prepares this._mapping for fast recoloring the mesh.
          */
         _mapMesh: {
-            value: function () {
+            value: function() {
                 if (!this._scene3d.geometry || !this._spots) return;
                 var args = {
                     verteces: this._scene3d.geometry.getAttribute('position').array,
                     spots: this._spots
                 };
-                this._doTask(Workspace.TaskType.MAP, args).then(function (results) {
+                this._doTask(Workspace.TaskType.MAP, args).then(function(results) {
                     this._scene3d.mapping = {
                         closestSpotIndeces: results.closestSpotIndeces,
                         closestSpotDistances: results.closestSpotDistances
@@ -322,7 +322,7 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
         },
 
         _cancelTask: {
-            value: function (taskType) {
+            value: function(taskType) {
                 if (taskType.key in this._tasks) {
                     this._tasks[taskType.key].worker.terminate();
                     delete this._tasks[taskType.key];
@@ -338,7 +338,7 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
          * @return {Promise}
          **/
         _doTask: {
-            value: function (taskType, args) {
+            value: function(taskType, args) {
                 if (taskType.key in this._tasks) this._cancelTask(taskType);
 
                 var task = {
@@ -354,8 +354,8 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
                 var addError = this._addError.bind(this);
 
                 task.worker.postMessage(args);
-                return new Promise(function (resolve, reject) {
-                    task.worker.onmessage = function (event) {
+                return new Promise(function(resolve, reject) {
+                    task.worker.onmessage = function(event) {
                         if (event.data.status == 'completed') {
                             setStatus('');
                             resolve(event.data);
@@ -372,7 +372,7 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
                             setStatus(event.data.message);
                         }
                     };
-                    task.worker.onerror = function (event) {
+                    task.worker.onerror = function(event) {
                         setStatus('');
                         addError('Operation failed. See log for details.');
                     }.bind(this);
@@ -381,10 +381,10 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
         },
 
         _updateMinMaxValues: {
-            value: function () {
+            value: function() {
                 var values = this._activeMeasure ? this._activeMeasure.values : [];
 
-                var values = Array.prototype.filter.call(values, this._scale.filter).sort(function (a, b) {
+                var values = Array.prototype.filter.call(values, this._scale.filter).sort(function(a, b) {
                     return a - b;
                 });
 
@@ -407,7 +407,7 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
         },
 
         _updateIntensities: {
-            value: function () {
+            value: function() {
                 if (!this._spots) return;
 
                 for (var i = 0; i < this._spots.length; i++) {
@@ -428,18 +428,18 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
         },
 
         _setStatus: {
-            value: function (status) {
+            value: function(status) {
                 this._status = status;
                 this._notify(Workspace.Events.STATUS_CHANGE);
             }
         },
 
         mode: {
-            get: function () {
+            get: function() {
                 return this._mode;
             },
 
-            set: function (value) {
+            set: function(value) {
                 if (this._mode == value) return;
                 this._mode = value;
 
@@ -465,35 +465,35 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
         },
 
         scene2d: {
-            get: function () {
+            get: function() {
                 return this._scene2d;
             }
         },
 
         scene3d: {
-            get: function () {
+            get: function() {
                 return this._scene3d;
             }
         },
 
         status: {
-            get: function () {
+            get: function() {
                 return this._status;
             }
         },
 
         measures: {
-            get: function () {
+            get: function() {
                 return this._measures || [];
             }
         },
 
         hotspotQuantile: {
-            get: function () {
+            get: function() {
                 return this._hotspotQuantile;
             },
 
-            set: function (value) {
+            set: function(value) {
                 if (this._hotspotQuantile == value) return;
                 if (value < 0.0) value = 0.0;
                 if (value > 1.0) value = 1.0;
@@ -505,11 +505,11 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
         },
 
         spotBorder: {
-            get: function () {
+            get: function() {
                 return this._spotBorder;
             },
 
-            set: function (value) {
+            set: function(value) {
                 if (this._spotBorder == value) return;
                 if (value < 0.0) value = 0.0;
                 if (value > 1.0) value = 1.0;
@@ -519,17 +519,17 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
         },
 
         scale: {
-            get: function () {
+            get: function() {
                 return this._scale;
             }
         },
 
         scaleId: {
-            get: function () {
+            get: function() {
                 return this._scale.id;
             },
 
-            set: function (value) {
+            set: function(value) {
                 if (this._scale.id == value) return;
                 this._scale = Workspace.getScaleById(value);
                 if (this._autoMinMax) this._updateMinMaxValues();
@@ -539,20 +539,20 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
         },
 
         colorMap: {
-            get: function () {
+            get: function() {
                 return this._colorMap;
             }
         },
 
         colorMapId: {
-            get: function () {
+            get: function() {
                 for (var i in ColorMap.Maps) {
                     if (this._colorMap === ColorMap.Maps[i]) return i;
                 }
 
             },
 
-            set: function (value) {
+            set: function(value) {
                 if (value in ColorMap.Maps) {
                     this._colorMap = ColorMap.Maps[value];
                     this._scene2d.colorMap = this._colorMap;
@@ -567,7 +567,7 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
      * Worker-like object what loads an image and calculate it sizes
      * (can't be a worker because uses Image).
      */
-    Workspace.ImageLoader = function () {
+    Workspace.ImageLoader = function() {
         this.onmessage = null;
         this._reader = new FileReader();
         this._reader.onload = this._onFileLoad.bind(this);
@@ -583,7 +583,7 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
     Workspace.TaskType.LOAD_IMAGE.worker = Workspace.ImageLoader;
 
     Workspace.ImageLoader.prototype = {
-        terminate: function () {
+        terminate: function() {
             this._terminated = true;
             if (this._reader.readyState == 1) {
                 this._reader.abort();
@@ -594,23 +594,23 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
             }
         },
 
-        postMessage: function (blob) {
+        postMessage: function(blob) {
             this._fileType = blob.type;
             this._reader.readAsArrayBuffer(blob);
         },
 
-        _send: function (message) {
+        _send: function(message) {
             if (!this._terminated && this.onmessage)
                 this.onmessage({data: message});
         },
 
-        _onFileLoad: function (event) {
+        _onFileLoad: function(event) {
             var blob = new Blob([event.target.result], {type: this._fileType});
             this._url = URL.createObjectURL(blob);
             this._image.src = this._url;
         },
 
-        _onImageLoad: function (event) {
+        _onImageLoad: function(event) {
             var url = this._url;
             this._url = null; // Ownership transfered.
             this._send({
@@ -621,13 +621,13 @@ function(ColorMap, EventSource, Scene2D, Scene3D, THREE) {
             });
         },
 
-        _onError: function (event) {
+        _onError: function(event) {
             console.info('Failure loading image', event);
             this._send({
                 status: 'failed',
                 message: 'Can not read image. See log for details.',
             });
-        },
+        }
     };
 
     return Workspace;

--- a/js/common.js
+++ b/js/common.js
@@ -1,7 +1,7 @@
 'use strict';
 
 define([],
-function () {
+function() {
     function asProps(object, props) {
         props = props || {};
         for (var i in object) {

--- a/js/main.js
+++ b/js/main.js
@@ -3,12 +3,10 @@
  */
 'use strict';
 
-define(['workspace', 'viewcontainer', 'mapselector', 'examples', 'dat',
-        'colormaps'],
-function(Workspace, ViewContainer, MapSelector, Examples, dat, ColorMap){
-    /*
-     * On load initialization.
-     */
+define([
+    'workspace', 'viewcontainer', 'viewgroup3d', 'mapselector', 'examples', 'datgui', 'colormaps'
+],
+function(Workspace, ViewContainer, ViewGroup3D, MapSelector, Examples, dat, ColorMap) {
     function init() {
         g_workspace = new Workspace();
         g_views = new ViewContainer(g_workspace, document.getElementById('view-container'));
@@ -30,7 +28,7 @@ function(Workspace, ViewContainer, MapSelector, Examples, dat, ColorMap){
         document.getElementById('open-button').onclick = chooseFilesToOpen;
         document.getElementById('current-map-label').onclick = function() {g_mapSelector.activate();};
         document.getElementById('view-container').onmousedown = function(event) {g_mapSelector.deactivate();};
-        document.querySelector('dialog#errors #close').onclick = clearErrors;
+        document.querySelector('div#errors #close').onclick = clearErrors;
 
         for (var e in DragAndDrop) {
             var fn = DragAndDrop[e];
@@ -100,8 +98,8 @@ function(Workspace, ViewContainer, MapSelector, Examples, dat, ColorMap){
     }
 
     function onWorkspaceErrorsChange() {
-        var dialog = document.querySelector('dialog#errors');
-        var list = dialog.querySelector('ul');
+        var errorBox = document.querySelector('div#errors');
+        var list = errorBox.querySelector('ul');
         list.textContent = '';
         g_workspace.errors.forEach(function(error) {
             var item = document.createElement('li');
@@ -109,11 +107,9 @@ function(Workspace, ViewContainer, MapSelector, Examples, dat, ColorMap){
             list.appendChild(item);
         });
         if (g_workspace.errors.length == 0) {
-            dialog.close();
-            dialog.hidden = true;
+            errorBox.setAttribute('hidden', 'true');
         } else {
-            dialog.hidden = false;
-            if (!dialog.open) dialog.showModal();
+            errorBox.removeAttribute('hidden');
         }
     }
 
@@ -252,5 +248,6 @@ function(Workspace, ViewContainer, MapSelector, Examples, dat, ColorMap){
         });
         fileInput.click();
     }
-      return init;
+
+    return init;
 });

--- a/js/workers/Downloader.js
+++ b/js/workers/Downloader.js
@@ -1,11 +1,12 @@
 'use strict';
 
-importScripts('../lib/require.js');
+importScripts('../lib/require.min.js');
 
 require({
     baseUrl: './'
-},
-['require'],
+}, [
+    'require'
+],
 function(require) {
     onmessage = function (e) {
         var fileNames = e.data;

--- a/js/workers/Downloader.js
+++ b/js/workers/Downloader.js
@@ -8,7 +8,7 @@ require({
     'require'
 ],
 function(require) {
-    onmessage = function (e) {
+    onmessage = function(e) {
         var fileNames = e.data;
         var downloader = new Downloader();
 
@@ -35,7 +35,7 @@ function(require) {
     Downloader.DATA_PATH = '../../data';
 
     Downloader.prototype = {
-        add: function (fileName) {
+        add: function(fileName) {
             var item = new Downloader.Item(fileName);
             item.request.onprogress = this.onProgress.bind(this, item);
             item.request.onerror = this.onError.bind(this, item);
@@ -43,20 +43,20 @@ function(require) {
             this.items.push(item);
         },
 
-        start: function () {
+        start: function() {
             for (var i = 0; i < this.items.length; i++) {
                 this.items[i].request.send();
             }
         },
 
-        onProgress: function (item, event) {
+        onProgress: function(item, event) {
             item.total = event.total;
             item.loaded = event.loaded;
 
-            var total = this._sum(function (item) {
+            var total = this._sum(function(item) {
                 return item.total;
             });
-            var loaded = this._sum(function (item) {
+            var loaded = this._sum(function(item) {
                 return item.loaded;
             });
 
@@ -68,12 +68,12 @@ function(require) {
             });
         },
 
-        onError: function (item, event) {
+        onError: function(item, event) {
             if (this.failed) return;
             this.failed = true;
 
             console.info('Error loading ' + item.fileName + ': ' + item.request.statusText, event);
-            this.items.forEach(function (item) {
+            this.items.forEach(function(item) {
                 item.request.abort();
             });
 
@@ -83,7 +83,7 @@ function(require) {
             });
         },
 
-        onLoad: function (item, event) {
+        onLoad: function(item, event) {
             if (item.request.status >= 300) {
                 this.onError(item, event);
                 return;
@@ -93,7 +93,7 @@ function(require) {
 
             postMessage({
                 status: 'completed',
-                items: this.items.map(function (item) {
+                items: this.items.map(function(item) {
                     return {
                         blob: item.request.response,
                         fileName: item.fileName
@@ -102,7 +102,7 @@ function(require) {
             });
         },
 
-        _sum: function (f) {
+        _sum: function(f) {
             var r = 0;
             for (var i = 0; i < this.items.length; i++) {
                 r += f(this.items[i]);
@@ -111,9 +111,9 @@ function(require) {
         },
     };
 
-    Downloader.Item = function (fileName) {
+    Downloader.Item = function(fileName) {
         var path = Downloader.DATA_PATH.split('/');
-        fileName.split('/').forEach(function (chunk) {
+        fileName.split('/').forEach(function(chunk) {
             if (!/^\w[\w\.-]*$/.test(chunk)) {
                 throw 'File "' + fileName + '" can\'t be downloaded';
             }

--- a/js/workers/Mapper.js
+++ b/js/workers/Mapper.js
@@ -6,12 +6,13 @@
 
 'use strict';
 
-importScripts('../lib/require.js');
+importScripts('../lib/require.min.js');
 
 require({
     baseUrl: './'
-},
-['require'],
+}, [
+    'require'
+],
 function(require) {
     onmessage = function(e) {
         var positions = e.data.verteces;

--- a/js/workers/MeasuresLoader.js
+++ b/js/workers/MeasuresLoader.js
@@ -15,12 +15,15 @@
  * highlighted.
  */
 
-importScripts('../lib/require.js');
+'use strict';
+
+importScripts('../lib/require.min.js');
 
 require({
-    baseUrl: './'
-},
-['require', 'papaparse'],
+    baseUrl: '../lib'
+}, [
+    'require', 'papaparse.min'
+],
 function(require, Papa) {
     onmessage = function (e) {
         var blob = e.data;
@@ -72,7 +75,7 @@ function(require, Papa) {
                 return;
             }
 
-            for (j = 0; j < this.measures.length; j++) {
+            for (var j = 0; j < this.measures.length; j++) {
                 var value = row[j + 5];
                 this.measures[j].values[this.spots.length] =
                     value === '' ? NaN : Number(value);

--- a/js/workers/MeasuresLoader.js
+++ b/js/workers/MeasuresLoader.js
@@ -25,7 +25,7 @@ require({
     'require', 'papaparse.min'
 ],
 function(require, Papa) {
-    onmessage = function (e) {
+    onmessage = function(e) {
         var blob = e.data;
         Papa.parse(blob, new Handler());
     };
@@ -41,7 +41,7 @@ function(require, Papa) {
     }
 
     Handler.prototype = {
-        _step: function (results, parser) {
+        _step: function(results, parser) {
             if (++this._row === 0) {
                 this._handleHeader(results.data[0]);
                 return;
@@ -86,8 +86,8 @@ function(require, Papa) {
             if (this._row % 10 === 0) this._reportProgress();
         },
 
-        _handleHeader: function (header) {
-            this.measures = header.slice(5).map(function (name, index) {
+        _handleHeader: function(header) {
+            this.measures = header.slice(5).map(function(name, index) {
                 return {
                     name: name,
                     index: index,
@@ -96,7 +96,7 @@ function(require, Papa) {
             });
         },
 
-        _complete: function () {
+        _complete: function() {
             // Convert measures in memory efficient format.
             for (var i = 0; i < this.measures.length; i++) {
                 var m = this.measures[i];
@@ -112,14 +112,14 @@ function(require, Papa) {
             });
         },
 
-        _reportError: function (message) {
+        _reportError: function(message) {
             postMessage({
                 status: 'failed',
                 message: 'Failure in row ' + this._row + ': ' + message,
             });
         },
 
-        _reportProgress: function () {
+        _reportProgress: function() {
             var now = new Date().valueOf();
             if (now < this._progressReportTime + 100) return;
 

--- a/js/workers/MeshLoader.js
+++ b/js/workers/MeshLoader.js
@@ -2,13 +2,16 @@
  * Web Worker. Loads a mesh from STL file.
  */
 
-importScripts('../lib/require.js');
+'use strict';
+
+importScripts('../lib/require.min.js');
 
 require({
-    baseUrl: './'
-},
-['require', 'stloader', 'three'],
-function (require, STLLoader, THREE) {
+    baseUrl: '../lib'
+}, [
+    'require', 'three.min', 'stlloader'
+],
+function(require, THREE, STLLoader) {
     onmessage = function(e) {
         var blob = e.data;
         var reader = new FileReaderSync();

--- a/js/workers/Raycaster.js
+++ b/js/workers/Raycaster.js
@@ -8,7 +8,7 @@ require({
     'require', 'three'
 ],
 function(require, THREE) {
-    onmessage = function (e) {
+    onmessage = function(e) {
         var startTime = new Date();
 
         var origin = new THREE.Vector3().copy(e.data.origin);

--- a/js/workers/Raycaster.js
+++ b/js/workers/Raycaster.js
@@ -4,8 +4,9 @@ importScripts('../lib/require.js');
 
 require({
     baseUrl: './'
-},
-['require', 'three'],
+}, [
+    'require', 'three'
+],
 function(require, THREE) {
     onmessage = function (e) {
         var startTime = new Date();


### PR DESCRIPTION
Summary:
- requirized `Examples.js` and `Scene2D.js` that were skipped before
- included missing stylesheets files to `index.html`
- fixed `dat.gui` module declaration
- added explicit call of `init()` function, as it seems `requirejs()` call, in `index.html`, happens after `window.onload` event is fired
- transformed `#errors` element in `index.html` from `dialog` to `div` as the former one is no longer supported by major browsers
- multiple code-style fixes in module definitions
